### PR TITLE
Update GitHub Project image and adjust image styling in HomepageFeatures

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -25,7 +25,7 @@ const FeatureList: FeatureItem[] = [
   },
   {
     title: "GitHub Project",
-    img: "https://github-readme-stats.vercel.app/api/pin/?username=difranca&repo=difranca.github.io",
+    img: "https://opengraph.githubassets.com/1/difranca/difranca.github.io",
     link: "https://github.com/difranca/difranca.github.io",
     description: (
       <>
@@ -49,7 +49,7 @@ function Feature({ title, link, img: img, description }: FeatureItem) {
     <div className={clsx("col col--6")}>
       <a className="text--center" href={link}>
         <div className="feature-logo">
-          <img src={img} alt={title} height="100px" width="333px"></img>
+          <img src={img} alt={title} style={{width: "333px", height: "174px", objectFit: "contain"}}></img>
         </div>
       </a>
       <div className="text--center padding-horiz--md">


### PR DESCRIPTION
This pull request updates the display of the GitHub Project feature on the homepage by improving the image source and adjusting the styling for better appearance.

**Homepage Feature Improvements:**

* Changed the `img` source for the GitHub Project feature to use GitHub's Open Graph image, providing a more visually consistent and up-to-date preview.
* Updated the `img` styling in the `Feature` component to use inline styles with specific width, height, and `objectFit: "contain"` for improved image presentation.