### PR TITLE
Add sitemap configuration

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -39,9 +39,15 @@ const config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl: "https://github.com/difranca/difranca.github.io/blob/main",
+          showLastUpdateTime: false,
         },
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
+        },
+        sitemap: {
+          lastmod: 'datetime',
+          changefreq: 'weekly',
+          priority: 0.5,
         },
         ...(process.env.NODE_ENV === "production" && {
           gtag: {


### PR DESCRIPTION
This pull request makes configuration updates to the Docusaurus site, primarily focusing on documentation options and sitemap settings.

Documentation and metadata configuration:

* Disabled the display of the "last updated" time on documentation pages by setting `showLastUpdateTime` to `false` in the docs configuration.

Sitemap improvements:

* Added a `sitemap` configuration section specifying `lastmod` as 'datetime', `changefreq` as 'weekly', and `priority` as 0.5 to improve search engine indexing and control sitemap behavior.